### PR TITLE
Fixes in config helper

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -7,111 +7,119 @@
  * @copyright Copyright (c) 2019 James Colannino
  * @license   https://www.gnu.org/licenses/gpl-3.0.en.html GPL v3
  */
+
 namespace Crankycyclops\DiscountCodeUrl\Helper;
 
-class Config extends \Magento\Framework\App\Helper\AbstractHelper
-{
-    /**
-     * The URL parameter we should look for to set the current coupon code.
-     *
-     * @var DEFAULT_URL_PARAMETER URL parameter containing the coupon code
-     */
-    public const DEFAULT_URL_PARAMETER = 'discount';
+class Config extends \Magento\Framework\App\Helper\AbstractHelper {
 
-    /**
-     * When a code is supplied via the URL, a cookie is set that allows us to
-     * remember it during a session.
-     *
-     * @var COUPON_COOKIE_NAME Name of cookie that stores discount code
-     */
-    public const COUPON_COOKIE_NAME = 'discount_coupon_url_code';
+	/**
+	 * The URL parameter we should look for to set the current coupon code.
+	 *
+	 * @var DEFAULT_URL_PARAMETER URL parameter containing the coupon code
+	 */
+	public const DEFAULT_URL_PARAMETER = 'discount';
 
-    /**
-     * This is how long a browser session should remember the last coupon code
-     * that was supplied via the URL in seconds. A default value of 0 means
-     * the cookie will last as long as the session (i.e. until the browser tab
-     * or window is closed.)
-     *
-     * @var DEFAULT_COOKIE_LIFETIME Default cookie lifetime in seconds
-     */
-    public const DEFAULT_COOKIE_LIFETIME = 0;
+	/**
+	 * When a code is supplied via the URL, a cookie is set that allows us to
+	 * remember it during a session.
+	 *
+	 * @var COUPON_COOKIE_NAME Name of cookie that stores discount code
+	 */
+	public const COUPON_COOKIE_NAME = 'discount_coupon_url_code';
 
-    /**
-     * @var ENABLED_CONFIG_PATH Whether or not the module is enabled
-     */
-    public const ENABLED_CONFIG_PATH = 'promo/discounturl/enabled';
+	/**
+	 * This is how long a browser session should remember the last coupon code
+	 * that was supplied via the URL in seconds. A default value of 0 means
+	 * the cookie will last as long as the session (i.e. until the browser tab
+	 * or window is closed.)
+	 *
+	 * @var DEFAULT_COOKIE_LIFETIME Default cookie lifetime in seconds
+	 */
+	public const DEFAULT_COOKIE_LIFETIME = 0;
 
-    /**
-     * @var URL_PARAMETER_CONFIG_PATH GET parameter that should set the coupon code
-     */
-    public const URL_PARAMETER_CONFIG_PATH = 'promo/discounturl/url_param';
+	/**
+	 * @var ENABLED_CONFIG_PATH Whether or not the module is enabled
+	 */
+	public const ENABLED_CONFIG_PATH = 'promo/discounturl/enabled';
 
-    /**
-     * @var PATH_ENABLED_PATH Whether or not to apply discount codes via the URL path
-     */
-    public const URL_PATH_ENABLED_PATH = 'promo/discounturl/url_path_enabled';
+	/**
+	 * @var URL_PARAMETER_CONFIG_PATH GET parameter that should set the coupon code
+	 */
+	public const URL_PARAMETER_CONFIG_PATH = 'promo/discounturl/url_param';
 
-    /**
-     * @var COOKIE_LIFETIME_CONFIG_PATH How long the cookie should last
-     */
-    public const COOKIE_LIFETIME_CONFIG_PATH = 'promo/discounturl/cookie_lifetime';
+	/**
+	 * @var PATH_ENABLED_PATH Whether or not to apply discount codes via the URL path
+	 */
+	public const URL_PATH_ENABLED_PATH = 'promo/discounturl/url_path_enabled';
 
-    /**
-     * Returns whether or not the module is enabled.
-     *
-     * @param string|int $scope
-     *
-     * @return bool
-     */
-    public function isEnabled($scope = 'default'): bool
-    {
+	/**
+	 * @var COOKIE_LIFETIME_CONFIG_PATH How long the cookie should last
+	 */
+	public const COOKIE_LIFETIME_CONFIG_PATH = 'promo/discounturl/cookie_lifetime';
+
+	/************************************************************************/
+
+	/**
+	 * Returns whether or not the module is enabled.
+	 *
+	 * @param string|int $scope
+	 *
+	 * @return bool
+	 */
+	public function isEnabled(): bool {
+
         return $this->scopeConfig->isSetFlag(self::ENABLED_CONFIG_PATH);
-    }
+	}
 
-    /**
-     * Returns whether or not the URL path feature is enabled.
-     *
-     * @param string|int $scope
-     *
-     * @return bool
-     */
-    public function isUrlPathEnabled($scope = 'default'): bool
-    {
+	/************************************************************************/
+
+	/**
+	 * Returns whether or not the URL path feature is enabled.
+	 *
+	 * @param string|int $scope
+	 *
+	 * @return bool
+	 */
+	public function isUrlPathEnabled(): bool {
+
         return $this->scopeConfig->isSetFlag(self::URL_PATH_ENABLED_PATH);
-    }
+	}
 
-    /**
-     * Returns whether or not the module is enabled.
-     *
-     * @param string|int $scope
-     *
-     * @return string
-     */
-    public function getUrlParameter($scope = 'default'): string
-    {
+	/************************************************************************/
+
+	/**
+	 * Returns whether or not the module is enabled.
+	 *
+	 * @param string|int $scope
+	 *
+	 * @return string
+	 */
+	public function getUrlParameter(): string {
+
         $value = $this->scopeConfig->getValue(self::URL_PARAMETER_CONFIG_PATH);
         return is_null($value) || '' === $value ? self::DEFAULT_URL_PARAMETER : $value;
-    }
+	}
 
-    /**
-     * Returns whether or not the module is enabled.
-     *
-     * @param string|int $scope
-     *
-     * @return int
-     */
-    public function getCookieLifetime(): int
-    {
+	/************************************************************************/
+
+	/**
+	 * Returns whether or not the module is enabled.
+	 *
+	 * @param string|int $scope
+	 *
+	 * @return int
+	 */
+	public function getCookieLifetime(): int {
+
         $value = $this->scopeConfig->getValue(self::COOKIE_LIFETIME_CONFIG_PATH);
         return (int) (is_null($value) || '' === $value ? self::DEFAULT_COOKIE_LIFETIME : $value);
-    }
+	}
 
-    /**
-     * Returns cookie name
-     * @return string
-     */
-    public function getCookieName(): string
-    {
+	/************************************************************************/
+
+	public function getCookieName(): string {
+
         return self::COUPON_COOKIE_NAME;
-    }
+	}
 }
+

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -68,7 +68,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper {
 	 */
 	public function isEnabled(): bool {
 
-        return $this->scopeConfig->isSetFlag(self::ENABLED_CONFIG_PATH);
+		return $this->scopeConfig->isSetFlag(self::ENABLED_CONFIG_PATH);
 	}
 
 	/************************************************************************/
@@ -82,7 +82,7 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper {
 	 */
 	public function isUrlPathEnabled(): bool {
 
-        return $this->scopeConfig->isSetFlag(self::URL_PATH_ENABLED_PATH);
+		return $this->scopeConfig->isSetFlag(self::URL_PATH_ENABLED_PATH);
 	}
 
 	/************************************************************************/
@@ -96,8 +96,8 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper {
 	 */
 	public function getUrlParameter(): string {
 
-        $value = $this->scopeConfig->getValue(self::URL_PARAMETER_CONFIG_PATH);
-        return is_null($value) || '' === $value ? self::DEFAULT_URL_PARAMETER : $value;
+		$value = $this->scopeConfig->getValue(self::URL_PARAMETER_CONFIG_PATH);
+		return is_null($value) || '' === $value ? self::DEFAULT_URL_PARAMETER : $value;
 	}
 
 	/************************************************************************/
@@ -111,15 +111,15 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper {
 	 */
 	public function getCookieLifetime(): int {
 
-        $value = $this->scopeConfig->getValue(self::COOKIE_LIFETIME_CONFIG_PATH);
-        return (int) (is_null($value) || '' === $value ? self::DEFAULT_COOKIE_LIFETIME : $value);
+		$value = $this->scopeConfig->getValue(self::COOKIE_LIFETIME_CONFIG_PATH);
+		return (int) (is_null($value) || '' === $value ? self::DEFAULT_COOKIE_LIFETIME : $value);
 	}
 
 	/************************************************************************/
 
 	public function getCookieName(): string {
 
-        return self::COUPON_COOKIE_NAME;
+		return self::COUPON_COOKIE_NAME;
 	}
 }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -7,162 +7,111 @@
  * @copyright Copyright (c) 2019 James Colannino
  * @license   https://www.gnu.org/licenses/gpl-3.0.en.html GPL v3
  */
-
 namespace Crankycyclops\DiscountCodeUrl\Helper;
 
-class Config extends \Magento\Framework\App\Helper\AbstractHelper {
+class Config extends \Magento\Framework\App\Helper\AbstractHelper
+{
+    /**
+     * The URL parameter we should look for to set the current coupon code.
+     *
+     * @var DEFAULT_URL_PARAMETER URL parameter containing the coupon code
+     */
+    public const DEFAULT_URL_PARAMETER = 'discount';
 
-	/**
-	 * The URL parameter we should look for to set the current coupon code.
-	 *
-	 * @var DEFAULT_URL_PARAMETER URL parameter containing the coupon code
-	 */
-	public const DEFAULT_URL_PARAMETER = 'discount';
+    /**
+     * When a code is supplied via the URL, a cookie is set that allows us to
+     * remember it during a session.
+     *
+     * @var COUPON_COOKIE_NAME Name of cookie that stores discount code
+     */
+    public const COUPON_COOKIE_NAME = 'discount_coupon_url_code';
 
-	/**
-	 * When a code is supplied via the URL, a cookie is set that allows us to
-	 * remember it during a session.
-	 *
-	 * @var COUPON_COOKIE_NAME Name of cookie that stores discount code
-	 */
-	public const COUPON_COOKIE_NAME = 'discount_coupon_url_code';
+    /**
+     * This is how long a browser session should remember the last coupon code
+     * that was supplied via the URL in seconds. A default value of 0 means
+     * the cookie will last as long as the session (i.e. until the browser tab
+     * or window is closed.)
+     *
+     * @var DEFAULT_COOKIE_LIFETIME Default cookie lifetime in seconds
+     */
+    public const DEFAULT_COOKIE_LIFETIME = 0;
 
-	/**
-	 * This is how long a browser session should remember the last coupon code
-	 * that was supplied via the URL in seconds. A default value of 0 means
-	 * the cookie will last as long as the session (i.e. until the browser tab
-	 * or window is closed.)
-	 *
-	 * @var DEFAULT_COOKIE_LIFETIME Default cookie lifetime in seconds
-	 */
-	public const DEFAULT_COOKIE_LIFETIME = 0;
+    /**
+     * @var ENABLED_CONFIG_PATH Whether or not the module is enabled
+     */
+    public const ENABLED_CONFIG_PATH = 'promo/discounturl/enabled';
 
-	/**
-	 * @var ENABLED_CONFIG_PATH Whether or not the module is enabled
-	 */
-	public const ENABLED_CONFIG_PATH = 'promo/discounturl/enabled';
+    /**
+     * @var URL_PARAMETER_CONFIG_PATH GET parameter that should set the coupon code
+     */
+    public const URL_PARAMETER_CONFIG_PATH = 'promo/discounturl/url_param';
 
-	/**
-	 * @var URL_PARAMETER_CONFIG_PATH GET parameter that should set the coupon code
-	 */
-	public const URL_PARAMETER_CONFIG_PATH = 'promo/discounturl/url_param';
+    /**
+     * @var PATH_ENABLED_PATH Whether or not to apply discount codes via the URL path
+     */
+    public const URL_PATH_ENABLED_PATH = 'promo/discounturl/url_path_enabled';
 
-	/**
-	 * @var PATH_ENABLED_PATH Whether or not to apply discount codes via the URL path
-	 */
-	public const URL_PATH_ENABLED_PATH = 'promo/discounturl/url_path_enabled';
+    /**
+     * @var COOKIE_LIFETIME_CONFIG_PATH How long the cookie should last
+     */
+    public const COOKIE_LIFETIME_CONFIG_PATH = 'promo/discounturl/cookie_lifetime';
 
-	/**
-	 * @var COOKIE_LIFETIME_CONFIG_PATH How long the cookie should last
-	 */
-	public const COOKIE_LIFETIME_CONFIG_PATH = 'promo/discounturl/cookie_lifetime';
+    /**
+     * Returns whether or not the module is enabled.
+     *
+     * @param string|int $scope
+     *
+     * @return bool
+     */
+    public function isEnabled($scope = 'default'): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::ENABLED_CONFIG_PATH);
+    }
 
-	/**
-	 * @var \Magento\Framework\App\Config\ScopeConfigInterface
-	 */
-	public $scopeConfig;
+    /**
+     * Returns whether or not the URL path feature is enabled.
+     *
+     * @param string|int $scope
+     *
+     * @return bool
+     */
+    public function isUrlPathEnabled($scope = 'default'): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::URL_PATH_ENABLED_PATH);
+    }
 
-	/************************************************************************/
+    /**
+     * Returns whether or not the module is enabled.
+     *
+     * @param string|int $scope
+     *
+     * @return string
+     */
+    public function getUrlParameter($scope = 'default'): string
+    {
+        $value = $this->scopeConfig->getValue(self::URL_PARAMETER_CONFIG_PATH);
+        return is_null($value) || '' === $value ? self::DEFAULT_URL_PARAMETER : $value;
+    }
 
-	/**
-	 * Constructor
-	 *
-	 * @param \Magento\Framework\App\Helper\Context $context
-	 * @param \Magento\Framework\Module\ModuleListInterface $moduleList
-	 */
-	public function __construct(
-		\Magento\Framework\App\Helper\Context $context,
-		\Magento\Framework\Module\ModuleListInterface $moduleList
-	) {
-		$this->scopeConfig = $context->getScopeConfig();
-		parent::__construct($context);
-	}
+    /**
+     * Returns whether or not the module is enabled.
+     *
+     * @param string|int $scope
+     *
+     * @return int
+     */
+    public function getCookieLifetime(): int
+    {
+        $value = $this->scopeConfig->getValue(self::COOKIE_LIFETIME_CONFIG_PATH);
+        return (int) (is_null($value) || '' === $value ? self::DEFAULT_COOKIE_LIFETIME : $value);
+    }
 
-	/************************************************************************/
-
-	/**
-	 * Returns whether or not the module is enabled.
-	 *
-	 * @param string|int $scope
-	 *
-	 * @return bool
-	 */
-	public function isEnabled($scope = 'default'): bool {
-
-		$value = $this->scopeConfig->getValue(
-			self::ENABLED_CONFIG_PATH,
-			\Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-			$scope
-		);
-
-		return is_null($value) || '0' == $value ? false : true;
-	}
-
-	/************************************************************************/
-
-	/**
-	 * Returns whether or not the URL path feature is enabled.
-	 *
-	 * @param string|int $scope
-	 *
-	 * @return bool
-	 */
-	public function isUrlPathEnabled($scope = 'default'): bool {
-
-		$value = $this->scopeConfig->getValue(
-			self::URL_PATH_ENABLED_PATH,
-			\Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-			$scope
-		);
-
-		return is_null($value) || '0' == $value ? false : true;
-	}
-
-	/************************************************************************/
-
-	/**
-	 * Returns whether or not the module is enabled.
-	 *
-	 * @param string|int $scope
-	 *
-	 * @return string
-	 */
-	public function getUrlParameter($scope = 'default'): string {
-
-		$value = $this->scopeConfig->getValue(
-			self::URL_PARAMETER_CONFIG_PATH,
-			\Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-			$scope
-		);
-
-		return is_null($value) || '' === $value ? self::DEFAULT_URL_PARAMETER : $value;
-	}
-
-	/************************************************************************/
-
-	/**
-	 * Returns whether or not the module is enabled.
-	 *
-	 * @param string|int $scope
-	 *
-	 * @return int
-	 */
-	public function getCookieLifetime($scope = 'default'): int {
-
-		$value = $this->scopeConfig->getValue(
-			self::COOKIE_LIFETIME_CONFIG_PATH,
-			\Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-			$scope
-		);
-
-		return is_null($value) || '' === $value ? self::DEFAULT_COOKIE_LIFETIME : $value;
-	}
-
-	/************************************************************************/
-
-	public function getCookieName(): string {
-
-		return self::COUPON_COOKIE_NAME;
-	}
+    /**
+     * Returns cookie name
+     * @return string
+     */
+    public function getCookieName(): string
+    {
+        return self::COUPON_COOKIE_NAME;
+    }
 }
-


### PR DESCRIPTION
- Removed constructor (moduleList is unused, scopeconfig already in abstracthelper)
- Replaced invalid scopeConfig usage with proper ones $scope="default" is incorrect as scopeType = \Magento\Store\Model\ScopeInterface::SCOPE_STORE in scopeConfig, meaning it only works on default magento website that has storeCode="default". Since scopeConfig of abstracthelper is already loaded in a storeview, there is no reason to pass scopeType/scopeId to that object.
- Replaced scopeConfig->getValue with IsSetFlag where possible.
- Added typecast on getCookieLifetime, as it will lead to an error since scopeConfig->getValue doesnt return int while getCookieLifetime is.